### PR TITLE
Allow Store Cache Time to Differ from Response

### DIFF
--- a/lib/grape/rails/cache.rb
+++ b/lib/grape/rails/cache.rb
@@ -11,9 +11,7 @@ module Grape
 
         helpers do
           def compare_etag(etag)
-            ::Rails.logger.debug("ETAG BEFORE: #{etag.inspect}")
             etag = Digest::SHA1.hexdigest(etag.to_s)
-            ::Rails.logger.debug("ETAG AFTER: #{etag} == #{request.headers["If-None-Match"]}")
             error!("Not Modified", 304) if request.headers["If-None-Match"] == etag
 
             header "ETag", etag


### PR DESCRIPTION
Sometimes we want the time a response is cached in the store to differ
from the validity period of the response.

This is specifically useful for id/hash-based fragments. These are
effectively valid forever however, we must always do some calculation to
ensure that this is the case (e.g. find the last updated time for a
record or selection of records).
