### PR TITLE
do not use Rails.cache with expired in 0

### DIFF
--- a/lib/grape/rails/cache.rb
+++ b/lib/grape/rails/cache.rb
@@ -54,9 +54,13 @@ module Grape
             end
 
             # Try to fetch from server side cache
-            cache_store_expire_time = opts[:cache_store_expires_in] || opts[:expires_in] || default_expire_time
-            ::Rails.cache.fetch(cache_key, raw: true, expires_in: cache_store_expire_time) do
+            cache_store_expire_time = (opts[:cache_store_expires_in] || opts[:expires_in] || default_expire_time).to_i
+            if cache_store_expire_time <= 0
               block.call.to_json
+            else
+              ::Rails.cache.fetch(cache_key, raw: true, expires_in: cache_store_expire_time) do
+                block.call.to_json
+              end
             end
           end
         end


### PR DESCRIPTION
Some cache stores crashed when were set expired_in 0.
And it is useless to cache with expired_in 0.

So I want to fix it. Check please.
