### PR TITLE
Force encoding as ascii-8bit before storing in rails cache

### DIFF
--- a/lib/grape/rails/cache.rb
+++ b/lib/grape/rails/cache.rb
@@ -59,7 +59,7 @@ module Grape
               block.call.to_json
             else
               ::Rails.cache.fetch(cache_key, raw: true, expires_in: cache_store_expire_time) do
-                block.call.to_json
+                block.call.to_json.force_encoding('ASCII-8BIT')
               end
             end
           end


### PR DESCRIPTION
When `raw: true` is set in Rails cache options, Rails expects a binary string as an input. No conversion is performed before sending the block result to the cache storage back-end.

When using the `Redis`/redis_cache_store as Rails.cache store, caching breaks if the json string to be cached contains non-ascii characters, like `{"name":"Obélix"}` for example.